### PR TITLE
Remove hardcoded Discord webhook username

### DIFF
--- a/atlas.sh
+++ b/atlas.sh
@@ -1,9 +1,9 @@
 #!/system/bin/sh
-# version 1.5.0
+# version 1.5.1
 
 #Version checks
 Ver55atlas="1.0"
-VerMonitor="3.1.7"
+VerMonitor="3.1.8"
 VerATVsender="1.6"
 
 #Create logfile

--- a/atlas_monitor.sh
+++ b/atlas_monitor.sh
@@ -73,7 +73,7 @@ do
 			[[ $debug == "true" ]] && echo "`date +%Y-%m-%d_%T` [MONITORBOT] atlas_config.json looks good" >> $logfile
 	else
 			echo "`date +%Y-%m-%d_%T` [MONITORBOT] atlas_config.json does not exist or is empty! Let's fix that" >> $logfile
-			[[ ! -z $discord_webhook ]] && [[ $recreate_atlas_config != "false" ]] && curl -S -k -L --fail --show-error -F "payload_json={\"username\": \"atlas monitor\", \"content\": \"__**$origin**__: re-creating atlas config\"}" $discord_webhook &>/dev/null
+			[[ ! -z $discord_webhook ]] && [[ $recreate_atlas_config != "false" ]] && curl -S -k -L --fail --show-error -F "payload_json={\"content\": \"__**$origin**__: re-creating atlas config\"}" $discord_webhook &>/dev/null
 			/system/bin/atlas.sh -ic
 			[[ $debug == "true" ]] && echo "`date +%Y-%m-%d_%T` [MONITORBOT] Fixed config" >> $logfile
 			stop_start_atlas
@@ -95,30 +95,30 @@ do
 	elif [ $not_licensed -gt 0 ]
 	then
 		echo "`date +%Y-%m-%d_%T` [MONITORBOT] Device Lost Atlas License" >> $logfile
-		[[ ! -z $discord_webhook ]] && curl -S -k -L --fail --show-error -F "payload_json={\"username\": \"atlas monitor\", \"content\": \"__**$origin**__: UNLICENSED !!! Check Atlas Dashboard\"}" $discord_webhook &>/dev/null
+		[[ ! -z $discord_webhook ]] && curl -S -k -L --fail --show-error -F "payload_json={\"content\": \"__**$origin**__: UNLICENSED !!! Check Atlas Dashboard\"}" $discord_webhook &>/dev/null
 		touch /sdcard/not_licensed
 
 	elif [ -f /sdcard/not_licensed ] && [ $not_licensed -eq 0 ]
 	then
 	        echo "`date +%Y-%m-%d_%T` [MONITORBOT] Device got License again. Recovering" >> $logfile
-                [[ ! -z $discord_webhook ]] && curl -S -k -L --fail --show-error -F "payload_json={\"username\": \"atlas monitor\", \"content\": \"__**$origin**__: Device got Atlas license again\"}" $discord_webhook &>/dev/null
+                [[ ! -z $discord_webhook ]] && curl -S -k -L --fail --show-error -F "payload_json={\"content\": \"__**$origin**__: Device got Atlas license again\"}" $discord_webhook &>/dev/null
 		rm /sdcard/not_licensed
 
         elif [ $emptycheck != 9 ] && [ $devicestatus != $deviceonline ] && [ $atlasdead == 2 ]
         then
                 echo "`date +%Y-%m-%d_%T` [MONITORBOT] Atlas must be dead, rebooting device" >> $logfile
-   	        [[ ! -z $discord_webhook ]] && [[ $atlas_died != "false" ]] && curl -S -k -L --fail --show-error -F "payload_json={\"username\": \"atlas monitor\", \"content\": \"__**$origin**__: atlas died, reboot\"}" $discord_webhook &>/dev/null
+   	        [[ ! -z $discord_webhook ]] && [[ $atlas_died != "false" ]] && curl -S -k -L --fail --show-error -F "payload_json={\"content\": \"__**$origin**__: atlas died, reboot\"}" $discord_webhook &>/dev/null
                 reboot
         elif [ $emptycheck != 9 ] && [ $pogodead == 2 ]
         then
                 echo "`date +%Y-%m-%d_%T` [MONITORBOT] Pogo must be dead, rebooting device" >> $logfile
-   	        [[ ! -z $discord_webhook ]] && [[ $pogo_died != "false" ]] && curl -S -k -L --fail --show-error -F "payload_json={\"username\": \"atlas monitor\", \"content\": \"__**$origin**__: pogo died, reboot\"}" $discord_webhook &>/dev/null
+   	        [[ ! -z $discord_webhook ]] && [[ $pogo_died != "false" ]] && curl -S -k -L --fail --show-error -F "payload_json={\"content\": \"__**$origin**__: pogo died, reboot\"}" $discord_webhook &>/dev/null
                 reboot
 
 	elif [ $emptycheck != 9 ] && [ $devicestatus != $deviceonline ] && [ $atlasdead != 2 ]
 	then
 		echo "`date +%Y-%m-%d_%T` [MONITORBOT] Device must be offline. Running a stop mapping service of Atlas, killing pogo and clearing junk" >> $logfile
-		[[ ! -z $discord_webhook ]] && [[ $device_offline != "false" ]] && curl -S -k -L --fail --show-error -F "payload_json={\"username\": \"atlas monitor\", \"content\": \"__**$origin**__: device offline, restarting atlas and pogo\"}" $discord_webhook &>/dev/null
+		[[ ! -z $discord_webhook ]] && [[ $device_offline != "false" ]] && curl -S -k -L --fail --show-error -F "payload_json={\"content\": \"__**$origin**__: device offline, restarting atlas and pogo\"}" $discord_webhook &>/dev/null
 		stop_start_atlas
 		atlasdead=$((atlasdead+1))
 		[[ $debug == "true" ]] && echo "`date +%Y-%m-%d_%T` [MONITORBOT] Done" >> $logfile
@@ -126,7 +126,7 @@ do
 	elif [ $emptycheck == 9 ]
 	then
 		echo "`date +%Y-%m-%d_%T` [MONITORBOT] Couldn't check status, something wrong with RDM?" >> $logfile
-		[[ ! -z $discord_webhook ]] && [[ $unable_check_status != "false" ]] && curl -S -k -L --fail --show-error -F "payload_json={\"username\": \"atlas monitor\", \"content\": \"__**$origin**__: unable to check status\"}" $discord_webhook &>/dev/null
+		[[ ! -z $discord_webhook ]] && [[ $unable_check_status != "false" ]] && curl -S -k -L --fail --show-error -F "payload_json={\"content\": \"__**$origin**__: unable to check status\"}" $discord_webhook &>/dev/null
 
 	elif [ $deviceonline == $devicestatus ]
 	then
@@ -136,7 +136,7 @@ do
 		if [ "$focusedapp" != "com.nianticlabs.pokemongo" ]
 		then
 			echo "`date +%Y-%m-%d_%T` [MONITORBOT] Something is not right! Pogo is not in focus. Killing pogo and clearing junk" >> $logfile
-			[[ ! -z $discord_webhook ]] && [[ $pogo_not_focused != "false" ]] && curl -S -k -L --fail --show-error -F "payload_json={\"username\": \"atlas monitor\", \"content\": \"__**$origin**__: pogo not in focus, Killing and clearing junk\"}" $discord_webhook &>/dev/null
+			[[ ! -z $discord_webhook ]] && [[ $pogo_not_focused != "false" ]] && curl -S -k -L --fail --show-error -F "payload_json={\"content\": \"__**$origin**__: pogo not in focus, Killing and clearing junk\"}" $discord_webhook &>/dev/null
 			stop_pogo
 			pogodead=$((pogodead+1))
 			[[ $debug == "true" ]] && echo "`date +%Y-%m-%d_%T` [MONITORBOT] Done" >> $logfile
@@ -146,7 +146,7 @@ do
 		fi
 	else
 		echo "`date +%Y-%m-%d_%T` [MONITORBOT] Something happened! Some kind of error" >> $logfile
-		[[ ! -z $discord_webhook ]] && curl -S -k -L --fail --show-error -F "payload_json={\"username\": \"atlas monitor\", \"content\": \"__**$origin**__: no clue what happend, but its not good\"}" $discord_webhook &>/dev/null
+		[[ ! -z $discord_webhook ]] && curl -S -k -L --fail --show-error -F "payload_json={\"content\": \"__**$origin**__: no clue what happend, but its not good\"}" $discord_webhook &>/dev/null
 	fi
 	sleep $monitor_interval
 done

--- a/atlas_monitor.sh
+++ b/atlas_monitor.sh
@@ -1,5 +1,5 @@
 #!/system/bin/sh
-# version 3.1.7
+# version 3.1.8
 
 # Monitor by Oldmole && bbdoc
 


### PR DESCRIPTION
Username is not a requirement, and why not let users have the option to call it whatever they want.
If username is not sent in the request, then it will use the "Name" set, while creating the webhook integration.