### PR TITLE
Update depreciated modules

### DIFF
--- a/wh_receiver/requirements.txt
+++ b/wh_receiver/requirements.txt
@@ -3,6 +3,6 @@ Flask==2.1.1
 PyMySQL==1.0.2
 requests==2.27.1
 mysql==0.0.3
-mysql-connector==2.2.9
+mysql-connector-python==8.0.31
 mysqlclient==2.1.0
 


### PR DESCRIPTION
`mysql-connector` is deprecated and has moved to `mysql-connector-python`. Tested working on Python 3.8.10 / Ubuntu 20.04.5 LTS.