### PR TITLE
more a9 fixes

### DIFF
--- a/scripts/atlas.sh
+++ b/scripts/atlas.sh
@@ -560,7 +560,11 @@ check_rgc
 if [[ -d /data/data/com.pokemod.atlas ]] && [[ ! -s $aconf ]] ;then
   install_config
   am force-stop com.pokemod.atlas
+  if [ $android_version -ge 9 ]; then
+  am start-foreground-service com.pokemod.atlas/com.pokemod.atlas.services.MappingService
+  else
   am startservice com.pokemod.atlas/com.pokemod.atlas.services.MappingService
+  fi
 fi
 
 # check 16/42mad pogo autoupdate disabled
@@ -597,6 +601,7 @@ if [[ -z $atlas_check ]] && [[ -f /data/local/tmp/atlas_config.json ]] ;then
     am start-foreground-service com.pokemod.atlas/com.pokemod.atlas.services.MappingService
   else
     am startservice com.pokemod.atlas/com.pokemod.atlas.services.MappingService
+  fi
 fi
 
 # check if playstore is enabled


### PR DESCRIPTION
Resolves #41 (thanks dkmur) and catches a missed if version check for another start service line. 


Does not however resolve an selinux issue at some point during # download atlas - I have no idea how to fix that, it isn't a part of the script that has been changed so maybe related to something a9 but doesn't seem to cause a failure either way.

```
cat atlas-install.log
avc:  denied  { read } for  scontext=u:r:system_server:s0 tcontext=u:object_r:fuseblk:s0 tclass=file permissive=1
Success
[2023-10-07T19:13:27 GMT] Installed Atlas
[2023-10-07T19:13:27 GMT] Magisk policy set so that Atlas can become root.
[2023-10-07T19:13:27 GMT] Done.
```

raised #43 for the above