### PR TITLE
freeze Werkzeug version at 2.3.7

### DIFF
--- a/wh_receiver/requirements.txt
+++ b/wh_receiver/requirements.txt
@@ -1,9 +1,8 @@
 configparser==5.2.0
-Flask==2.1.1
+Flask==2.2.5
 PyMySQL==1.0.2
-requests==2.27.1
+requests==2.31.0
 mysql==0.0.3
-mysql-connector==2.2.9
+mysql-connector-python==8.0.31
 mysqlclient==2.1.0
 Werkzeug==2.3.7
-

--- a/wh_receiver/requirements.txt
+++ b/wh_receiver/requirements.txt
@@ -5,4 +5,5 @@ requests==2.27.1
 mysql==0.0.3
 mysql-connector==2.2.9
 mysqlclient==2.1.0
+Werkzeug==2.3.7
 


### PR DESCRIPTION
## Summary
Fix compatibility issue between Flask 2.1.1 and Werkzeug 3.x.x

## Description
This pull request addresses the runtime error encountered with Flask 2.1.1 due to incompatibility with certain Werkzeug versions. It resolves the following error:
`ImportError: cannot import name 'url_quote' from 'werkzeug.urls'`


## Details of the Fix
- Ensures `wh_receiver` can run on the latest compatible versions of dependencies, contributing to stability in the aconf core.
- Highlights the necessity for Flask and Werkzeug to maintain version compatibility, especially across major releases.

## Changes Made
- Freeze Werkzeug version to avoid compatibility issues with Flask 2.1.1. The application is verified stable with Werkzeug versions 2.2.2 and 2.3.7.
- Issues are expected with Werkzeug versions +3.x.x; recommend caution with future updates.

## Context for Changes
- The changes are crucial for maintaining a stable aconf core, given the ongoing updates to Android 9 on ATVs, leading to the recommendation not to update Flask at the current stage.
- Refer to conversations highlighted in [Pogo Tools Discord](https://discord.com/channels/639191866822098944/681977009055989940/1166837948268941412).

## Future Considerations
- Suggests a detailed review of these dependencies when the project priorities turn towards dependency updates. Significant enhancements or fixes in major releases could be beneficial for aconf.
- Noteworthy that Werkzeug's release history on [PyPI Werkzeug history](https://pypi.org/project/Werkzeug/#history) marks 2.3.7 as the final 2.x.x release on 14 August 2023 before transitioning to 3.x.x versions, which could introduce breaking changes.

## Testing
- Rapid local testing was conducted in Docker, confirming that aconf experiences no runtime errors and functions as intended with Werkzeug versions 2.2.2 and 2.3.7.
- Performance observed by running `@G3neRaL` on bare metal.

## Request for Feedback/Review
- Insights or reviews are highly welcomed.
- Discussions are open regarding potential risks or additional considerations that may not have been previously identified.
